### PR TITLE
fix(readme): correct NixOS networkmanager option name

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ programs.hyprland.enable = true;
 
 # Required services
 services.geoclue2.enable = true;  # For QtPositioning
-services.networkmanager.enable = true;  # For network management
+networking.networkmanager.enable = true;  # For network management
 services.upower.enable = true; # For battery status
 
 # System fonts (optional but recommended)


### PR DESCRIPTION
Replaced invalid networkmanager option with the correct one:
[networking.networkmanager.enable](https://search.nixos.org/options?channel=25.11&show=networking.networkmanager.enable)